### PR TITLE
Fix: Duplicates in result for `get_ancestors_of`

### DIFF
--- a/src/pedpol/generations.py
+++ b/src/pedpol/generations.py
@@ -58,7 +58,7 @@ def _get_relatives_of(
 
     if include_ids:
         relatives.append(ids)
-    ids_relatives = pl.concat(relatives)
+    ids_relatives = pl.concat(relatives).unique()
     if isinstance(pedigree, pl.LazyFrame):
         ids_relatives = ids_relatives.lazy()
     return pedigree.join(ids_relatives, on=animal)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 from pedpol.core import null_unknown_parents
 from pedpol.generations import classify_generations
+from pedpol.validation import add_missing_records
 
 data_dir = Path(__file__).absolute().parent / "resources"
 
@@ -60,8 +61,25 @@ def ped_errors():
 @pytest.fixture
 def ped_lit():
     ped = pl.read_csv(
-        data_dir / "ped_literal.csv", schema_overrides=3 * [pl.Utf8], comment_prefix="#"
+        data_dir / "ped_literal.csv",
+        schema_overrides=3 * [pl.Utf8],
+        comment_prefix="#",
     ).pipe(null_unknown_parents, parent_labels=("Father", "Mother"))
+    return ped, (ped.columns)
+
+
+@pytest.fixture
+def ped_lit_valid():
+    ped = (
+        pl.read_csv(
+            data_dir / "ped_literal.csv",
+            schema_overrides=3 * [pl.Utf8],
+            comment_prefix="#",
+        )
+        .pipe(null_unknown_parents, parent_labels=("Father", "Mother"))
+        .pipe(add_missing_records, pedigree_labels=("Child", "Father", "Mother"))
+    )
+
     return ped, (ped.columns)
 
 

--- a/tests/pedpol/test_generations.py
+++ b/tests/pedpol/test_generations.py
@@ -62,14 +62,14 @@ def test_lazy_get_ancestors_of_single_id(ped_jv):
     assert get_ancestors_of(ped.lazy(), ids, pedigree_labels=lbls).collect().height == 9
 
 
-def test_get_ancestors_of_multiple_literal_ids(ped_lit):
-    ped, lbls = ped_lit
+def test_get_ancestors_of_multiple_literal_ids(ped_lit_valid):
+    ped, lbls = ped_lit_valid
     ids = ["Barry", "Emily"]
-    assert get_ancestors_of(ped, ids, pedigree_labels=lbls).height == 6
+    assert get_ancestors_of(ped, ids, pedigree_labels=lbls).height == 13
 
 
-def test_get_1gen_ancestors_same_as_get_parents(ped_lit):
-    ped, lbls = ped_lit
+def test_get_1gen_ancestors_same_as_get_parents(ped_lit_valid):
+    ped, lbls = ped_lit_valid
     ids = ["Barry", "Emily"]
     assert (
         get_ancestors_of(
@@ -84,8 +84,8 @@ def test_get_descendents_of_single_id(ped_jv):
     assert get_descendants_of(ped, [3], pedigree_labels=lbls).height == 11
 
 
-def test_get_descendents_of_single_literal_id(ped_lit):
-    ped, lbls = ped_lit
+def test_get_descendents_of_single_literal_id(ped_lit_valid):
+    ped, lbls = ped_lit_valid
     assert get_descendants_of(ped, ["Harry"], pedigree_labels=lbls).height == 8
 
 


### PR DESCRIPTION
Fixes #1

Ensures that list of relatives to subset/join with the original pedigree is unique.